### PR TITLE
Update to bta_hh_api.h to fix Joy-Con Input Lag.

### DIFF
--- a/bta/include/bta_hh_api.h
+++ b/bta/include/bta_hh_api.h
@@ -33,7 +33,7 @@
 #endif
 
 #ifndef BTA_HH_SSR_MAX_LATENCY_DEF
-#define BTA_HH_SSR_MAX_LATENCY_DEF 800 /* 500 ms*/
+#define BTA_HH_SSR_MAX_LATENCY_DEF 24 /* 500 ms*/
 #endif
 
 #ifndef BTA_HH_SSR_MIN_TOUT_DEF


### PR DESCRIPTION
Change BTA_HH_SSR_MAX_LATENCY_DEF value to 24 in order to Fix Nintendo Joy-Con Input Lag.